### PR TITLE
Avoid duplicated items

### DIFF
--- a/src/rbr/RBR.java
+++ b/src/rbr/RBR.java
@@ -6,7 +6,7 @@ import java.util.*;
 
 public class RBR {
 	private Graph graph;
-	private HashMap<Vertex, ArrayList<RoutingOption>> routingPathForVertex;
+	private HashMap<Vertex, Set<RoutingOption>> routingPathForVertex;
 	private HashMap<Vertex, ArrayList<Region>> regionsForVertex;
 
 	public RBR(Graph g) {
@@ -22,8 +22,8 @@ public class RBR {
 	// Pack routing options if they have the same input port and the same
 	// destination
 	private void packOutputPort(Vertex atual) {
-		ArrayList<RoutingOption> actRP = routingPathForVertex.get(atual);
-		routingPathForVertex.put(atual, new ArrayList<>());
+		Set<RoutingOption> actRP = routingPathForVertex.get(atual);
+		routingPathForVertex.put(atual, new HashSet<>());
 		for (RoutingOption a : actRP) {
 			Set<Character> op = a.getOp();
 			Set<Character> ip = a.getIp();
@@ -41,8 +41,8 @@ public class RBR {
 	// Pack routing options if they have the same output port and the same
 	// destination
 	public void packInputPort(Vertex atual) {
-		ArrayList<RoutingOption> actRP = routingPathForVertex.get(atual);
-		routingPathForVertex.put(atual, new ArrayList<>());
+		Set<RoutingOption> actRP = routingPathForVertex.get(atual);
+		routingPathForVertex.put(atual, new HashSet<>());
 		for (RoutingOption a : actRP) {
 			Set<Character> op = a.getOp();
 			Set<Character> ip = a.getIp();
@@ -60,7 +60,7 @@ public class RBR {
 	public void addRoutingOptions(ArrayList<ArrayList<Path>> paths) {
 
 		for(Vertex v : graph.getVertices())
-			routingPathForVertex.put(v, new ArrayList<>());
+			routingPathForVertex.put(v, new HashSet<>());
 
 		for(ArrayList<Path> alp : paths) {
 			for (Path path : alp) {
@@ -344,8 +344,7 @@ public class RBR {
 
 	private void addRoutingPath(Vertex v, Set<Character> ip, Vertex dst, Set<Character> op) {
 		RoutingOption rp = new RoutingOption(ip, dst, op);
-		// @Todo replace this by a Set to not worry with duplication
-		if(!routingPathForVertex.get(v).contains(rp))
-			routingPathForVertex.get(v).add(rp);
+		
+		routingPathForVertex.get(v).add(rp);
 	}
 }

--- a/src/rbr/RBR.java
+++ b/src/rbr/RBR.java
@@ -34,7 +34,7 @@ public class RBR {
 						op.addAll(b.getOp());
 				}
 			}
-			addRoutingPath(atual, ip, dst, op);
+			routingPathForVertex.get(atual).add(new RoutingOption(ip, dst, op));
 		}
 	}
 
@@ -53,7 +53,7 @@ public class RBR {
 						ip.addAll(b.getIp());
 				}
 			}
-			addRoutingPath(atual, ip, dst, op);
+			routingPathForVertex.get(atual).add(new RoutingOption(ip, dst, op));
 		}
 	}
 
@@ -76,7 +76,7 @@ public class RBR {
 						else {
 							ip.add(graph.adjunct(sw, path.get(path.indexOf(sw) - 1) ).color());
 						}
-						addRoutingPath(sw, ip, path.dst(), op);
+						routingPathForVertex.get(sw).add(new RoutingOption(ip, path.dst(), op));
 					}
 				}
 			}
@@ -340,11 +340,5 @@ public class RBR {
 			}
 		}
 		return false;
-	}
-
-	private void addRoutingPath(Vertex v, Set<Character> ip, Vertex dst, Set<Character> op) {
-		RoutingOption rp = new RoutingOption(ip, dst, op);
-		
-		routingPathForVertex.get(v).add(rp);
 	}
 }

--- a/src/rbr/RoutingOption.java
+++ b/src/rbr/RoutingOption.java
@@ -41,4 +41,12 @@ class RoutingOption {
 			return false;
 		return true;
 	}
+	
+	@Override
+	public int hashCode(){
+		int result = ip.hashCode();
+		result = 37 * result + op.hashCode();
+		result = 37 * result + dst.hashCode();
+		return result;
+	}
 }

--- a/tests/rbr/RoutingOptionTest.java
+++ b/tests/rbr/RoutingOptionTest.java
@@ -1,0 +1,48 @@
+package rbr;
+
+import java.util.*;
+import org.junit.*;
+import util.*;
+
+public class RoutingOptionTest {
+
+	private Vertex sw;
+
+	@Before
+	public void setUp() {
+		sw = new Vertex("01");
+    }
+
+	@Test
+	public void equalsTest(){
+		Assert.assertEquals(newRoutingOption("E", this.sw, "W"), newRoutingOption("E", this.sw, "W"));
+	}
+
+	@Test
+	public void notEqualsTest(){
+		Assert.assertNotEquals(newRoutingOption("ENW", this.sw, "S"), newRoutingOption("EW", this.sw, "S"));
+	}
+
+	@Test
+	public void hashCodeEqualsTest(){
+		Assert.assertEquals(newRoutingOption("W", this.sw, "S").hashCode(), newRoutingOption("W", this.sw, "S").hashCode());
+	}
+
+	@Test
+	public void hashCodeNotEqualsTest(){
+		Assert.assertNotEquals(newRoutingOption("E", this.sw, "NW").hashCode(), newRoutingOption("N", this.sw, "WE").hashCode());
+	}
+
+	private RoutingOption newRoutingOption(String ip, Vertex vertex, String op){
+		Set<Character> inputPorts = new HashSet<>();
+		for(Character c : ip.toCharArray()){
+			inputPorts.add(c);
+		}
+
+		Set<Character> outputPorts = new HashSet<>();
+		for(Character c : op.toCharArray()){
+			outputPorts.add(c);
+		}
+		return new RoutingOption(inputPorts, vertex, outputPorts);
+	}
+}


### PR DESCRIPTION
Use of Set collection on the vertex routing paths instead of ArrayList to avoid any duplicated items on the collection. To modify this and ensure the exclusivity of each item, was necessary to override the equals() and hashCode() methods of RoutingOption class. An unitary test was successfully done.
