### PR TITLE
Override Vertex equals

### DIFF
--- a/src/sbr/Segment.java
+++ b/src/sbr/Segment.java
@@ -19,8 +19,7 @@ public class Segment {
         if (links.size() == 1)
             return false;
 
-        if (links.get(links.size() - 1).destination().name()
-                .equals(switches.get(0).name()))
+        if (links.get(links.size() - 1).destination().equals(switches.get(0)))
             return true;
 
         return false;

--- a/src/util/Graph.java
+++ b/src/util/Graph.java
@@ -24,11 +24,11 @@ public class Graph {
     }
 
     private void reachAdjuncts(Vertex vertex, Set<Vertex> reachable) {
-        if (reachable.contains(vertex)){
+        if (reachable.contains(vertex)) {
             return;
         }
         reachable.add(vertex);
-        for (Edge adj : adjunctsOf(vertex)){
+        for (Edge adj : adjunctsOf(vertex)) {
             Vertex neigh = adj.destination();
             reachAdjuncts(neigh, reachable);
         }
@@ -46,9 +46,9 @@ public class Graph {
         return this.adjuncts.get(v);
     }
 
-    public Edge adjunct(Vertex src, Vertex dst){
-        for(Edge edge : adjunctsOf(src)){
-            if (edge.destination().name().equals(dst.name())) {
+    public Edge adjunct(Vertex src, Vertex dst) {
+        for (Edge edge : adjunctsOf(src)) {
+            if (edge.destination().equals(dst)) {
                 return edge;
             }
         }
@@ -56,9 +56,9 @@ public class Graph {
         return null;
     }
 
-    public Edge adjunctOf(Vertex v, Character color){
-        for(Edge edge : adjunctsOf(v)){
-            if(edge.color().equals(color)){
+    public Edge adjunctOf(Vertex v, Character color) {
+        for (Edge edge : adjunctsOf(v)) {
+            if (edge.color().equals(color)) {
                 return edge;
             }
         }
@@ -68,7 +68,6 @@ public class Graph {
 
     public Vertex vertex(String name) {
         Vertex vertex = null;
-
         for (Vertex v : this.vertices) {
             if (v.name().equals(name)) {
                 vertex = v;
@@ -76,21 +75,20 @@ public class Graph {
         }
 
         if (vertex == null) {
-            System.out.println("Vertex: " + name + " nao encontrado");
+            System.out.println("Vertex: " + name + " was not found");
             return null;
         }
-
         return vertex;
     }
 
-    void addVertex(String nome) {
-        Vertex v = new Vertex(nome);
+    void addVertex(String name) {
+        Vertex v = new Vertex(name);
         vertices.add(v);
         adjuncts.put(v, new ArrayList<>());
     }
 
-    void addEdge(Vertex src, Vertex dst, Character cor) {
-        addEdge(new Edge(src, dst, cor));
+    void addEdge(Vertex src, Vertex dst, Character color) {
+        addEdge(new Edge(src, dst, color));
     }
 
     void addEdge(Edge toAdd) {
@@ -132,6 +130,6 @@ public class Graph {
     private int indexOf(String xy) {
         int x = Integer.parseInt(xy.split("\\.")[0]);
         int y = Integer.parseInt(xy.split("\\.")[1]);
-        return x + y*this.dimX();
+        return x + y * this.dimX();
     }
 }

--- a/src/util/Vertex.java
+++ b/src/util/Vertex.java
@@ -23,4 +23,9 @@ public class Vertex {
 
         return (x <= xMax && x >= xMin && y <= yMax && y >= yMin);
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        return ((obj instanceof Vertex) && (((Vertex) obj).name().equals(this.name)));
+    }
 }

--- a/tests/VertexTest.java
+++ b/tests/VertexTest.java
@@ -1,0 +1,26 @@
+import org.junit.*;
+import util.Vertex;
+
+public class VertexTest {
+    @Test
+    public void VertexEqualsOverrideTest() throws Exception {
+        Vertex a = new Vertex("0.0");
+        Vertex b = new Vertex("0.0");
+        Vertex c = new Vertex("0.0");
+        Vertex d = new Vertex("1.1");
+        // reflexive property
+        Assert.assertTrue(a.equals(a));
+        // symmetric property
+        Assert.assertTrue(a.equals(b) == b.equals(a));
+        // transitive property
+        if (a.equals(b) && b.equals(c)) {
+            Assert.assertTrue(a.equals(c));
+        }
+        // consistency property
+        Assert.assertTrue(a.equals(b) == a.equals(b));
+        // non-null property
+        Assert.assertFalse(a.equals(null));
+        // test with different Vertex
+        Assert.assertFalse(a.equals(d));
+    }
+}


### PR DESCRIPTION
Override equals at Vertex in order to directly compare two vertices. Also, includes a unity test to test the equals properties.

Commit:Mod

TaskNumber:#61
