### PR TITLE
Rename variables names from dimX to columns and dimY to rows

### DIFF
--- a/src/rbr/RoutingTableGenerator.java
+++ b/src/rbr/RoutingTableGenerator.java
@@ -14,7 +14,7 @@ public class RoutingTableGenerator {
     public RoutingTableGenerator(Graph graph, HashMap<Vertex, ArrayList<Region>> regionsForVertex) {
         this.graph = graph;
         this.regionsForVertex = regionsForVertex;
-        int size = Math.max(graph.dimX(), graph.dimY());
+        int size = Math.max(graph.columns(), graph.rows());
         this.bitPerCoordinate = (int) Math.ceil(Math.log(size) / Math.log(2));
         this.maxOfRegions = maxOfRegions();
     }

--- a/src/rsbr.java
+++ b/src/rsbr.java
@@ -13,24 +13,24 @@ public class rsbr {
         String volumePath = null;
         boolean shouldMerge = true;
         int dim = 4;
-        int dimX = dim;
-        int dimY = dim;
+        int rows = dim;
+        int columns = dim;
         double[] faultyPercentages = { 0.0, 0.05, 0.1, 0.15, 0.2, 0, 25, 0.30 };
 
         if (args.length == 4) {
-            dimX = Integer.parseInt(args[0]);
-            dimY = Integer.parseInt(args[1]);
+            rows = Integer.parseInt(args[0]);
+            columns = Integer.parseInt(args[1]);
         }
 
         for (double faultyPercentage : faultyPercentages) {
 
-            if (!hasEnoughEdges(dimX, dimY, faultyPercentage))
+            if (!hasEnoughEdges(rows, columns, faultyPercentage))
                 break;
 
             System.out.println("Generating graph");
             Graph graph = (topologyFile != null) ?
                     FromFileGraphBuilder.generateGraph(topologyFile) :
-                    RandomFaultyGraphBuilder.generateGraph(dimX, dimY, (int)Math.ceil(faultyPercentage*numberOfEdges(dimX, dimY)));
+                    RandomFaultyGraphBuilder.generateGraph(rows, columns, (int)Math.ceil(faultyPercentage*numberOfEdges(rows, columns)));
 
             System.out.println("Isolated?: " + graph.hasIsolatedCores());
 
@@ -88,8 +88,8 @@ public class rsbr {
         new RoutingTableGenerator(graph, rbr.regions()).doRoutingTable(fileSuffix);
     }
 
-    private static int numberOfEdges(int dimX, int dimY) {
-        return (dimX - 1)*dimY + (dimY - 1)*dimX;
+    private static int numberOfEdges(int rows, int columns) {
+        return (columns - 1)*rows + (rows - 1)*columns;
     }
 
     private static ArrayList<ArrayList<Path>> selectPaths(ArrayList<ArrayList<Path>> paths, Graph g, Map<Path, Double> volumes) {
@@ -114,10 +114,10 @@ public class rsbr {
         return chosenPaths;
     }
 
-    private static boolean hasEnoughEdges(int dimX, int dimY, double percentage) {
-        int numberOfFaultyEdges = (int) Math.ceil((double) numberOfEdges(dimX, dimY) * percentage);
-        int numberOfGoodEdges = numberOfEdges(dimX, dimY) - numberOfFaultyEdges;
-        int numberOfVertices = dimX * dimY;
+    private static boolean hasEnoughEdges(int rows, int columns, double percentage) {
+        int numberOfFaultyEdges = (int) Math.ceil((double) numberOfEdges(rows, columns) * percentage);
+        int numberOfGoodEdges = numberOfEdges(rows, columns) - numberOfFaultyEdges;
+        int numberOfVertices = rows * columns;
 
         return (numberOfGoodEdges >= numberOfVertices - 1);
     }
@@ -138,7 +138,7 @@ public class rsbr {
 
     private static Map<Path, Double> communicationVolume(ArrayList<ArrayList<Path>> paths, File commvol, Graph graph) {
 
-        int N = graph.dimX()*graph.dimY();
+        int N = graph.columns()*graph.rows();
         double[][] vol = new double[N][N];
         double maxVol = 0;
         Map<Path, Double> pathsVolume = new HashMap<>();

--- a/src/sbr/SR.java
+++ b/src/sbr/SR.java
@@ -42,8 +42,8 @@ public class SR {
     }
 
     public void computeSegments() {
-        int maxX = graph.dimX()-1;
-        int maxY = graph.dimY()-1;
+        int maxX = graph.columns()-1;
+        int maxY = graph.rows()-1;
         for (int currentY = maxY; currentY >= 0; currentY--) {
             currentWindow = Range.TwoDimensionalRange(0, maxX, currentY, maxY);
             computeSegmentsInRange();

--- a/src/util/FromFileGraphBuilder.java
+++ b/src/util/FromFileGraphBuilder.java
@@ -15,16 +15,16 @@ public class FromFileGraphBuilder {
         try {
             Scanner sc = new Scanner(new FileReader(topology));
 
-            String[] lines = sc.nextLine().split("; ");
-            String[] columns = sc.nextLine().split("; ");
+            String[] strLines = sc.nextLine().split("; ");
+            String[] strColumns = sc.nextLine().split("; ");
 
-            int dimX = lines[0].split(" ").length + 1;
-            int dimY = lines.length;
+            int columns = strLines[0].split(" ").length + 1;
+            int rows = strLines.length;
 
-            result = new Graph(dimX, dimY);
+            result = new Graph(rows, columns);
             addVertices(result);
-            addHorizontalLinks(result, lines, columns);
-            addVerticalLinks(result, columns);
+            addHorizontalLinks(result, strLines, strColumns);
+            addVerticalLinks(result, strColumns);
             sc.close();
 
         } catch (Exception ex) {
@@ -34,8 +34,8 @@ public class FromFileGraphBuilder {
     }
 
     static private void addVertices(Graph graph) {
-        for (int i = 0; i < graph.dimX(); i++) {
-            for (int j = 0; j < graph.dimY(); j++) {
+        for (int i = 0; i < graph.columns(); i++) {
+            for (int j = 0; j < graph.rows(); j++) {
                 String vertex = i + "." + j;
                 graph.addVertex(vertex);
             }

--- a/src/util/Graph.java
+++ b/src/util/Graph.java
@@ -6,15 +6,15 @@ public class Graph {
     private ArrayList<Vertex> vertices;
     private ArrayList<Edge> edges;
     private Map<Vertex, Collection<Edge>> adjuncts;
-    private int dimX;
-    private int dimY;
+    private int columns;
+    private int rows;
 
     public Graph(int rows, int columns) {
         vertices = new ArrayList<>();
         edges = new ArrayList<>();
         adjuncts = new HashMap<>();
-        dimX = columns;
-        dimY = rows;
+        this.columns = columns;
+        this.rows = rows;
     }
 
     public boolean hasIsolatedCores() {
@@ -115,12 +115,12 @@ public class Graph {
         return r;
     }
 
-    public int dimX() {
-        return dimX;
+    public int columns() {
+        return columns;
     }
 
-    public int dimY() {
-        return dimY;
+    public int rows() {
+        return rows;
     }
 
     public int indexOf(Vertex v) {
@@ -130,6 +130,6 @@ public class Graph {
     private int indexOf(String xy) {
         int x = Integer.parseInt(xy.split("\\.")[0]);
         int y = Integer.parseInt(xy.split("\\.")[1]);
-        return x + y * this.dimX();
+        return x + y * this.columns();
     }
 }

--- a/src/util/RandomFaultyGraphBuilder.java
+++ b/src/util/RandomFaultyGraphBuilder.java
@@ -2,10 +2,10 @@ package util;
 
 public class RandomFaultyGraphBuilder {
 
-    static public Graph generateGraph(int dimX, int dimY, int numberOfFaultyEdges) {
-        Graph result = RegularGraphBuilder.generateGraph(dimX, dimY);
+    static public Graph generateGraph(int rows, int columns, int numberOfFaultyEdges) {
+        Graph result = RegularGraphBuilder.generateGraph(rows, columns);
         int totalOfEdges = result.getEdges().size()/2;
-        assert totalOfEdges - numberOfFaultyEdges >= dimX*dimY - 1;
+        assert totalOfEdges - numberOfFaultyEdges >= rows*columns - 1;
         for(int i = 0; i < numberOfFaultyEdges; i++)
             removeNoBridgeLink(result);
         return result;

--- a/src/util/RegularGraphBuilder.java
+++ b/src/util/RegularGraphBuilder.java
@@ -1,16 +1,16 @@
 package util;
 
 public class RegularGraphBuilder {
-    static public Graph generateGraph(int dimX, int dimY) {
-        Graph result = new Graph(dimX, dimY);
+    static public Graph generateGraph(int rows, int columns) {
+        Graph result = new Graph(rows, columns);
         addVertices(result);
         addEdges(result);
         return result;
     }
 
     static private void addVertices(Graph graph) {
-        for (int i = 0; i < graph.dimX(); i++) {
-            for (int j = 0; j < graph.dimY(); j++) {
+        for (int i = 0; i < graph.columns(); i++) {
+            for (int j = 0; j < graph.rows(); j++) {
                 String name = i + "." + j;
                 graph.addVertex(name);
             }
@@ -18,8 +18,8 @@ public class RegularGraphBuilder {
     }
 
     static private void addEdges(Graph graph) {
-        for(int y = 0; y < graph.dimY(); y++) {
-            for(int x = 0; x < graph.dimX(); x++) {
+        for(int y = 0; y < graph.rows(); y++) {
+            for(int x = 0; x < graph.columns(); x++) {
                 Vertex current = graph.vertex(x + "." + y);
                 if(contains(graph, x + "." + (y + 1)))
                     graph.addEdge(current, graph.vertex(x + "." + (y + 1)), TopologyKnowledge.colorFromTo(x + "." + y, x + "." + (y + 1)));

--- a/tests/FaultyGraphSegmentationTest.java
+++ b/tests/FaultyGraphSegmentationTest.java
@@ -19,10 +19,10 @@ public class FaultyGraphSegmentationTest {
 
     @Test
     public void faultyGraph() throws Exception {
-        for (int x = 2; x < 8; x++) {
-            for (int y = 2; y < 8; y++) {
-                for (int numberOfFaults = 0; numberOfFaults <= maxOfFaultyLinks(x, y); numberOfFaults++) {
-                    Graph noc = RandomFaultyGraphBuilder.generateGraph(x, y, numberOfFaults);
+        for (int numberOfRows = 2; numberOfRows < 8; numberOfRows++) {
+            for (int numberOfColumns = 2; numberOfColumns < 8; numberOfColumns++) {
+                for (int numberOfFaults = 0; numberOfFaults <= maxOfFaultyLinks(numberOfRows, numberOfColumns); numberOfFaults++) {
+                    Graph noc = RandomFaultyGraphBuilder.generateGraph(numberOfRows, numberOfColumns, numberOfFaults);
                     SR sr = new SR(noc, new BidimensionalSBRPolicy(noc));
                     sr.computeSegments();
                     sr.setrestrictions();


### PR DESCRIPTION
This patch makes uniform the use of dimensions and coordinates to specify network topology avoiding confusion.
#81 was caused by a misunderstood related with the issue above.
