### PR TITLE
Adds vertex hashCode overriding

### DIFF
--- a/src/util/Vertex.java
+++ b/src/util/Vertex.java
@@ -22,4 +22,9 @@ public final class Vertex {
     public boolean equals(Object obj) {
         return ((obj instanceof Vertex) && (((Vertex) obj).name().equals(this.name)));
     }
+
+    @Override
+    public int hashCode() {
+        return (name != null) ? name.hashCode() : 0;
+    }
 }

--- a/tests/VertexTest.java
+++ b/tests/VertexTest.java
@@ -23,4 +23,11 @@ public class VertexTest {
         // test with different Vertex
         Assert.assertFalse(a.equals(d));
     }
+
+    @Test
+    public void SameVerticesHaveSameHashCode() throws Exception {
+        Vertex oneVertex = new Vertex("5.3");
+        Vertex theSameVertex = new Vertex("5.3");
+        Assert.assertEquals(oneVertex.hashCode(), theSameVertex.hashCode());
+    }
 }


### PR DESCRIPTION
Implements Vertex.hashCode() as it is widely used in HashSets and as key
in HashMaps.
Adds also a testing showing that it's works.

Commit: Add