### PR TITLE
Make Range.abuts() symmetric

### DIFF
--- a/src/util/Range.java
+++ b/src/util/Range.java
@@ -109,7 +109,7 @@ public class Range {
             return false;
         }
         for(int i = 0; i < numberOfDimensions; i++) {
-            if(that.min(i) > this.max(i)) {
+            if(that.min(i) > this.max(i) || that.max(i) < this.min(i)) {
                 return false;
             }
         }


### PR DESCRIPTION
Fix symmetry bug in Range.abuts(). The order of the parameters can not influence the return.

Commit:Mod

TaskNumber:#97