### PR TITLE
Refactor sbr find

### DIFF
--- a/src/sbr/SR.java
+++ b/src/sbr/SR.java
@@ -1,11 +1,11 @@
 package sbr;
 
 import util.*;
+
 import java.util.*;
 
 public class SR {
 
-    private final boolean debug = false;
     private Range currentWindow;
 
     private Graph graph;
@@ -16,34 +16,32 @@ public class SR {
     private Segment currentSegment;
     private List<Edge> bridges;
 
-    private List<Vertex> visitedVertices, unvisitedVertices, start, terminal;
+    private List<Vertex> visitedVertices, unvisitedVertices;
+    private List<Vertex> startVertices, terminalVertices;
     private List<Edge> visitedEdges, unvisitedEdges;
-    private HashMap<Vertex, Segment> segmentForVertex;
     private HashMap<Vertex, Integer> subnetForVertex;
     private SBRPolicy policy;
 
-    public SR(Graph graph , SBRPolicy policy)
-    {
+    public SR(Graph graph, SBRPolicy policy) {
         this.policy = policy;
         this.graph = graph;
         this.restrictions = new GraphRestrictions(graph);
         segments = new ArrayList<>();
         visitedVertices = new ArrayList<>();
         unvisitedVertices = new ArrayList<>(graph.getVertices());
-        start = new ArrayList<>();
-        terminal = new ArrayList<>();
+        startVertices = new ArrayList<>();
+        terminalVertices = new ArrayList<>();
         visitedEdges = new ArrayList<>();
         unvisitedEdges = new ArrayList<>(graph.getEdges());
         bridges = new Bridge(graph).bridges();
         subNet = 0;
         maxSN = -1;
-        segmentForVertex = new HashMap<>();
         subnetForVertex = new HashMap<>();
     }
 
     public void computeSegments() {
-        int maxX = graph.columns()-1;
-        int maxY = graph.rows()-1;
+        int maxX = graph.columns() - 1;
+        int maxY = graph.rows() - 1;
         for (int currentY = maxY; currentY >= 0; currentY--) {
             currentWindow = Range.TwoDimensionalRange(0, maxX, currentY, maxY);
             computeSegmentsInRange();
@@ -57,201 +55,11 @@ public class SR {
     }
 
     public Collection<Vertex> terminalVertices() {
-        return terminal;
+        return terminalVertices;
     }
 
     public Collection<Vertex> startVertices() {
-        return start;
-    }
-
-    private void computeSegmentsInRange() {
-        terminal = new ArrayList<>();
-
-        Vertex start = pickFirstVertex();
-        while (start != null) {
-            computeSegmentsInExistingSubNets(start);
-            start = pickNextStartVertex();
-            /* If no segment was created from the start vertex picked and the graph has no bridges
-            (ideal places to pick starts) then we should try to pick any non-visited vertex to
-            start forming segments even in the first run.
-            Even if the graph does have bridges, in the case no segment was formed at all I cannot
-            see a problem in pick 'any' vertex to start segments.
-             */
-        }
-    }
-
-    private void computeSegmentsInExistingSubNets(Vertex sw) {
-        while (null != sw) {
-            policy.resetRRIndex();
-            subNet = subnetForVertex.get(sw);
-            Segment seg = formSegmentFrom(sw);
-            if(segmentIsValid(seg))
-                segments.add(seg);
-            sw = nextVisited();
-        }
-    }
-
-    private boolean segmentIsValid(Segment seg) {
-        return (null != seg && !seg.getLinks().isEmpty());
-    }
-
-    private Vertex pickFirstVertex() {
-        int xMin = currentWindow.min(0);
-        int yMin = currentWindow.min(1);
-        int xMax = currentWindow.max(0)-1;
-        int yMax = currentWindow.max(1)-1;
-
-        boolean isFirstTurn = (yMin + 1 == yMax);
-        Vertex sw;
-        Vertex left = graph.vertex(xMin + "." + yMin);
-        Vertex right = graph.vertex(xMax + "." + yMin);
-        boolean pair = ((yMin + 1) % 2 == 0);
-
-        if (isFirstTurn) {
-            sw = (pair) ? left : right;
-            setStart(sw);
-            subnetForVertex.put(sw, ++maxSN);
-            return sw;
-        }
-
-        if (isVisited(left) || isVisited(right)) {
-            sw = (isVisited(left)) ? left : right;
-            return sw;
-        }
-
-        sw = nextVisited();
-        if (null != sw) {
-            return sw;
-        }
-
-        sw = nextBridgeLinkedStartVertex();
-        if (sw == null) {
-            sw = (pair) ? left : right;
-        }
-        setStart(sw);
-        subnetForVertex.put(sw, ++maxSN);
-        return sw;
-    }
-
-    private Segment formSegmentFrom(Vertex sw) {
-        currentSegment = new Segment();
-        Segment segment = null;
-        if (find(sw)) {
-            segment = currentSegment;
-        } else if (isVisited(sw)) {
-            setTerminal(sw);
-        } else if (isFinalTurn()) {
-            visit(sw);
-            setTerminal(sw);
-        } else {
-            unsetStart(sw);
-        }
-        return segment;
-    }
-
-    private Vertex pickNextStartVertex() {
-        Vertex sw = null;
-        if (isFinalTurn() && (sw = nextBridgeLinkedStartVertex()) != null) {
-            setStart(sw);
-            subnetForVertex.put(sw, ++maxSN);
-        }
-        return sw;
-    }
-
-    private boolean isFinalTurn() {
-        return (currentWindow.min(0) == 0 && currentWindow.min(1) == 0);
-    }
-
-    private boolean find(Vertex sw) {
-        Segment segm = currentSegment;
-        if (!isVisited(sw)) {
-            segm.add(sw);
-            segmentForVertex.put(sw, segm);
-            setTVisited(sw);
-        } else if (subnetForVertex.get(sw) != subNet && !(isStart(sw) && isTerminal(sw)))
-            return false;
-
-        ArrayList<Edge> links = suitableLinks(sw);
-        while (!links.isEmpty()) {
-            Edge ln = policy.getNextLink(links);
-            links.remove(ln);
-            Edge nl = graph.adjunct(ln.destination(), ln.source());
-            if (debug) System.err.println("Link now: "+ln.source().name()+" <-> "+ln.destination().name());
-            setTVisited(ln);
-            setTVisited(nl);
-            segm.add(ln);
-            Vertex nsw = ln.destination();
-            if (nsw.isIn(currentWindow)) {
-                if (((isVisited(nsw) || isStart(nsw)) && subnetForVertex.get(nsw) == subNet) || find(nsw)) {
-                    visit(ln);
-                    visit(nl);
-                    if(!isVisited(sw)) visit(sw);
-                    if(!isVisited(nsw)) visit(nsw);
-                    if (isTerminal(nsw) && isStart(nsw) && subnetForVertex.get(nsw) != subNet && !segmentForVertex.containsKey(nsw)) {
-                        unsetTerminal(nsw);
-                        unsetStart(nsw);
-                        segm.add(nsw);
-                        segmentForVertex.put(nsw, segm);
-                    }
-                    subnetForVertex.put(nsw, subNet);
-                    return true;
-                }
-            }
-            unsetTVisited(ln);
-            unsetTVisited(nl);
-            segm.remove(ln);
-        }
-        segm.remove(sw);
-        segmentForVertex.remove(sw);
-        if(isTVisited(sw)) unsetTVisited(sw);
-        return false;
-    }
-
-    private Vertex nextVisited() {
-        List<Vertex> suitables = suitableVisitedVertices();
-        Collections.reverse(suitables);
-        for (Vertex tic : suitables) {
-            if (suitableLinks(tic).size() > 1)
-                return tic;
-            for (int j = suitables.indexOf(tic) + 1; j < suitables.size(); j++) {
-                Vertex tac = suitables.get(j);
-                if (subnetForVertex.get(tic).equals(subnetForVertex.get(tac))) {
-                    return tic;
-                }
-            }
-        }
-        return null;
-    }
-
-    private List<Vertex> suitableVisitedVertices() {
-        ArrayList<Vertex> result = new ArrayList<>();
-        for (Vertex sw : visitedVertices) {
-            if (!isTerminal(sw) && sw.isIn(currentWindow) && hasSuitableLinks(sw))
-                    result.add(sw);
-        }
-        return result;
-    }
-
-    private Vertex nextBridgeLinkedStartVertex() {
-        for (Edge b: bridges) {
-            Vertex dst = b.destination();
-            if(canBeStart(dst)) {
-                return dst;
-            }
-            Vertex src = b.source();
-            if(canBeStart(src)) {
-                return src;
-            }
-        }
-        return null;
-    }
-
-    private boolean canBeStart(Vertex sw) {
-        return (!isVisited(sw) && sw.isIn(currentWindow));
-    }
-
-    private boolean hasSuitableLinks(Vertex sw) {
-        return !suitableLinks(sw).isEmpty();
+        return startVertices;
     }
 
     public GraphRestrictions restrictions() {
@@ -260,20 +68,17 @@ public class SR {
 
     public void setrestrictions() {
         for (Segment segment : segments) {
-            if (segment.getLinks().isEmpty()) {
-                continue;
-            }
             if (segment.isUnitary()) {
                 // No traffic allowed at link
                 Vertex Starting = segment.getLinks().get(0).source();
                 Vertex Ending = segment.getLinks().get(0).destination();
                 // Restrictions at Starting core
                 for (Edge link : graph.adjunctsOf(Starting)) {
-                        restrictions.addRestriction(Starting, link.color(), graph.adjunct(Starting, Ending).color());
+                    restrictions.addRestriction(Starting, link.color(), graph.adjunct(Starting, Ending).color());
                 }
                 // Restrictions at Ending core
                 for (Edge link : graph.adjunctsOf(Ending)) {
-                        restrictions.addRestriction(Ending, link.color(),  graph.adjunct(Ending, Starting).color());
+                    restrictions.addRestriction(Ending, link.color(), graph.adjunct(Ending, Starting).color());
                 }
                 continue;
             }
@@ -299,105 +104,261 @@ public class SR {
         }
     }
 
-    private boolean isVisited(Vertex v) {
-        return visitedVertices.contains(v);
+    private void computeSegmentsInRange() {
+        terminalVertices = new ArrayList<>();
+
+        Vertex start = pickFirstVertex();
+        while (start != null) {
+            computeSegmentsInExistingSubNets(start);
+            start = pickNextStartVertex();
+            /* If no segment was created from the start vertex picked and the graph has no bridges
+            (ideal places to pick starts) then we should try to pick any non-visited vertex to
+            start forming segments even in the first run.
+            Even if the graph does have bridges, in the case no segment was formed at all I cannot
+            see a problem in pick 'any' vertex to start segments.
+             */
+        }
     }
 
-    private void visit(Vertex v) {
-        assert !visitedVertices.contains(v) : "Vertex jah visitado?";
-        //assert unvisitedVertices.contains(v) : "Vertex (t)visitado?";
+    private Vertex pickFirstVertex() {
+        int xMin = currentWindow.min(0);
+        int yMin = currentWindow.min(1);
+        int xMax = currentWindow.max(0) - 1;
+        int yMax = currentWindow.max(1) - 1;
 
-        visitedVertices.add(v);
-        unvisitedVertices.remove(v);
+        boolean isFirstTurn = (yMin + 1 == yMax);
+        Vertex sw;
+        Vertex left = graph.vertex(xMin + "." + yMin);
+        Vertex right = graph.vertex(xMax + "." + yMin);
+        boolean pair = ((yMin + 1) % 2 == 0);
+
+        if (isFirstTurn) {
+            sw = (pair) ? left : right;
+            setStart(sw);
+            subnetForVertex.put(sw, ++maxSN);
+            return sw;
+        }
+
+        sw = nextVisited();
+        if (null != sw) {
+            return sw;
+        }
+
+        sw = nextBridgeLinkedStartVertex();
+        if (sw == null) {
+            sw = (pair) ? left : right;
+        }
+        setStart(sw);
+        subnetForVertex.put(sw, ++maxSN);
+        return sw;
     }
 
-    private boolean isVisited(Edge a) {
-        return visitedEdges.contains(a);
+    private void computeSegmentsInExistingSubNets(Vertex sw) {
+        while (null != sw) {
+            policy.resetRRIndex();
+            subNet = subnetForVertex.get(sw);
+            Segment seg = formSegmentFrom(sw);
+            if (segmentIsValid(seg)) {
+                segments.add(seg);
+                visit(seg);
+            }
+            sw = nextVisited();
+        }
     }
 
-    private void visit(Edge a) {
-        assert !visitedEdges.contains(a) : "Edge jah visitada?";
-        //assert unvisitedEdges.contains(a) : "Edge (t)visitada?";
-
-        visitedEdges.add(a);
-        unvisitedEdges.remove(a);
+    private void visit(Segment segment) {
+        for (Vertex v : segment.getSwitchs()) {
+            visit(v);
+            subnetForVertex.put(v, subNet);
+        }
+        for (Edge e : segment.getLinks()) {
+            visit(e);
+        }
     }
 
-    private boolean isTVisited(Vertex v) {
-        return !visitedVertices.contains(v) && !unvisitedVertices.contains(v);
+    private Vertex pickNextStartVertex() {
+        Vertex sw = null;
+        if (isFinalTurn() && (sw = nextBridgeLinkedStartVertex()) != null) {
+            setStart(sw);
+            subnetForVertex.put(sw, ++maxSN);
+        }
+        return sw;
     }
 
-    private void setTVisited(Vertex v) {
-        assert !visitedVertices.contains(v) : "Vertex jah visitado?";
-        assert unvisitedVertices.contains(v) : "Vertex jah tvisitado?";
-
-        unvisitedVertices.remove(v);
+    private Vertex nextVisited() {
+        List<Vertex> suitables = suitableVisitedVertices();
+        Collections.reverse(suitables);
+        for (Vertex tic : suitables) {
+            if (suitableLinks(tic).size() > 1)
+                return tic;
+            for (int j = suitables.indexOf(tic) + 1; j < suitables.size(); j++) {
+                Vertex tac = suitables.get(j);
+                if (subnetForVertex.get(tic).equals(subnetForVertex.get(tac))) {
+                    return tic;
+                }
+            }
+        }
+        return null;
     }
 
-    private boolean isTVisited(Edge a) {
-        return !visitedEdges.contains(a) && !unvisitedEdges.contains(a);
+    private Vertex nextBridgeLinkedStartVertex() {
+        for (Edge b : bridges) {
+            Vertex dst = b.destination();
+            if (canBeStart(dst)) {
+                return dst;
+            }
+            Vertex src = b.source();
+            if (canBeStart(src)) {
+                return src;
+            }
+        }
+        return null;
     }
 
-    private void setTVisited(Edge a) {
-        assert unvisitedEdges.contains(a) : "Edge jah tvisitada?";
-
-        unvisitedEdges.remove(a);
+    private Segment formSegmentFrom(Vertex sw) {
+        currentSegment = new Segment();
+        if (!isVisited(sw)) {
+            currentSegment.add(sw);
+        }
+        Segment segment = extendedSegment(currentSegment, sw);
+        if (!segmentIsValid(segment)) {
+            if (isVisited(sw)) {
+                setTerminal(sw);
+            } else if (isFinalTurn()) {
+                visit(sw);
+                setTerminal(sw);
+            } else {
+                unsetStart(sw);
+            }
+        }
+        return segment;
     }
 
-    private void unsetTVisited(Edge a) {
-        assert !unvisitedEdges.contains(a) : "Edge nao tvisitada?";
-
-        unvisitedEdges.add(a);
+    private boolean segmentIsValid(Segment seg) {
+        return (null != seg && !seg.getLinks().isEmpty());
     }
 
-    private void unsetTVisited(Vertex v) {
-        assert !unvisitedVertices.contains(v) : "Vertex nao tvisitado?";
-
-        unvisitedVertices.add(v);
+    private boolean isFinalTurn() {
+        return (currentWindow.min(0) == 0 && currentWindow.min(1) == 0);
     }
 
-    private boolean isStart(Vertex v) {
-        return start.contains(v);
+    private List<Vertex> suitableVisitedVertices() {
+        ArrayList<Vertex> result = new ArrayList<>();
+        for (Vertex sw : visitedVertices) {
+            if (!isTerminal(sw) && sw.isIn(currentWindow) && hasSuitableLinks(sw))
+                result.add(sw);
+        }
+        return result;
     }
 
-    private void setStart(Vertex v) {
-        assert !start.contains(v) : "Vertex jah start?";
-
-        start.add(v);
+    private boolean hasSuitableLinks(Vertex sw) {
+        return !suitableLinks(sw).isEmpty();
     }
 
-    private void unsetStart(Vertex v) {
-        assert start.contains(v) : "Vertex nao start?";
-
-        start.remove(v);
+    private boolean canBeStart(Vertex sw) {
+        return (!isVisited(sw) && sw.isIn(currentWindow));
     }
 
-    private boolean isTerminal(Vertex v) {
-        return terminal.contains(v);
+    private Segment extendedSegment(Segment base, Vertex from) {
+        ArrayList<Edge> links = suitableLinks(from, base);
+        Segment extendedSegment = null;
+        while (!links.isEmpty() && !segmentIsValid(extendedSegment)) {
+            Edge currentLink = policy.getNextLink(links);
+            links.remove(currentLink);
+            extendedSegment = extendedSegment(new Segment(base, currentLink));
+        }
+        return extendedSegment;
     }
 
-    private void setTerminal(Vertex v) {
-        assert !terminal.contains(v) : "Vertex jah terminal?";
-        assert visitedVertices.contains(v) : "Vertex nao tvisitado?";
-
-        terminal.add(v);
-    }
-
-    private void unsetTerminal(Vertex v) {
-        assert terminal.contains(v) : "Vertex nao terminal?";
-
-        terminal.remove(v);
+    private Segment extendedSegment(Segment edgeEndedSegment) {
+        Edge currentLink = edgeEndedSegment.getLinks().get(edgeEndedSegment.getLinks().size() - 1);
+        Vertex nextVertex = currentLink.destination();
+        if (isVisited(nextVertex) && subnetForVertex.get(nextVertex) == subNet) {
+            return edgeEndedSegment;
+        } else if (isStart(nextVertex) && subnetForVertex.get(nextVertex) == subNet) {
+            return edgeEndedSegment;
+        }
+        return extendedSegment(new Segment(edgeEndedSegment, nextVertex), nextVertex);
     }
 
     private ArrayList<Edge> suitableLinks(Vertex v) {
         ArrayList<Edge> result = new ArrayList<>();
-        for(Edge ln : graph.adjunctsOf(v)) {
+        for (Edge ln : graph.adjunctsOf(v)) {
             Vertex dst = ln.destination();
-            boolean cruza = isTVisited(dst) && !isStart(dst);
             boolean isBridge = bridges.contains(ln) || bridges.contains(graph.adjunct(dst, ln.source()));
-            if(!isVisited(ln) && !isTVisited(ln) && dst.isIn(currentWindow) && !cruza && !isBridge)
+            if (!isVisited(ln) && dst.isIn(currentWindow) && !isBridge)
                 result.add(ln);
         }
         return result;
+    }
+
+    private ArrayList<Edge> suitableLinks(Vertex v, Segment segment) {
+        currentSegment = segment;
+        ArrayList<Edge> result = new ArrayList<>();
+        for (Edge ln : graph.adjunctsOf(v)) {
+            Vertex dst = ln.destination();
+            boolean crosses = isTVisited(dst) && !isStart(dst);
+            boolean isBridge = bridges.contains(ln) || bridges.contains(graph.adjunct(dst, ln.source()));
+            if (!isVisited(ln) && !isTVisited(ln) && dst.isIn(currentWindow) && !crosses && !isBridge)
+                result.add(ln);
+        }
+        return result;
+    }
+
+    private boolean isVisited(Vertex aVertex) {
+        return visitedVertices.contains(aVertex);
+    }
+
+    private void visit(Vertex aVertex) {
+        visitedVertices.add(aVertex);
+        unvisitedVertices.remove(aVertex);
+    }
+
+    private boolean isTVisited(Vertex aVertex) {
+        return currentSegment.getSwitchs().contains(aVertex);
+    }
+
+    private boolean isVisited(Edge anEdge) {
+        return visitedEdges.contains(anEdge);
+    }
+
+    private void visit(Edge anEdge) {
+        Edge itsSibling = graph.adjunct(anEdge.destination(), anEdge.source());
+        visitedEdges.add(anEdge);
+        visitedEdges.add(itsSibling);
+        unvisitedEdges.remove(anEdge);
+        unvisitedEdges.remove(itsSibling);
+    }
+
+    private boolean isTVisited(Edge anEdge) {
+        Edge itsSibling = graph.adjunct(anEdge.destination(), anEdge.source());
+        return (currentSegment.getLinks().contains(anEdge) || currentSegment.getLinks().contains(itsSibling));
+    }
+
+    private void setStart(Vertex aVertex) {
+        assert !isStart(aVertex) : "Vertex already startVertices";
+
+        startVertices.add(aVertex);
+    }
+
+    private void unsetStart(Vertex aVertex) {
+        assert isStart(aVertex) : "Vertex not startVertices";
+
+        startVertices.remove(aVertex);
+    }
+
+    private boolean isStart(Vertex aVertex) {
+        return startVertices.contains(aVertex);
+    }
+
+    private void setTerminal(Vertex aVertex) {
+        assert !isTerminal(aVertex) : "Vertex already terminalVertices";
+        assert isVisited(aVertex) : "Vertex not visited";
+
+        terminalVertices.add(aVertex);
+    }
+
+    private boolean isTerminal(Vertex aVertex) {
+        return terminalVertices.contains(aVertex);
     }
 }

--- a/src/sbr/Segment.java
+++ b/src/sbr/Segment.java
@@ -12,6 +12,21 @@ public class Segment {
         switches = new ArrayList<>();
     }
 
+    public Segment(Segment that, Edge toAppend) {
+        this(that);
+        this.add(toAppend);
+    }
+
+    public Segment(Segment that, Vertex toAppend) {
+        this(that);
+        this.add(toAppend);
+    }
+
+    public Segment(Segment that) {
+        this.links = new ArrayList<>(that.links);
+        this.switches = new ArrayList<>(that.switches);
+    }
+
     public boolean isStarting() {
         // Checa se o destino do ultimo link eh o primeiro switch
 

--- a/tests/FaultyGraphSegmentationTest.java
+++ b/tests/FaultyGraphSegmentationTest.java
@@ -13,6 +13,8 @@ public class FaultyGraphSegmentationTest {
                 sr.computeSegments();
                 sr.setrestrictions();
                 edgesAreEitherInASegmentOrAreBridges(noc, sr.segments());
+                verticesAreEitherInASegmentOrAreAloneInASubnet(noc, sr);
+                //onlyTerminalVerticesAreLinkedToBridges(noc, sr);
             }
         }
     }
@@ -28,6 +30,7 @@ public class FaultyGraphSegmentationTest {
                     sr.setrestrictions();
                     edgesAreEitherInASegmentOrAreBridges(noc, sr.segments());
                     verticesAreEitherInASegmentOrAreAloneInASubnet(noc, sr);
+                    //onlyTerminalVerticesAreLinkedToBridges(noc, sr);
                 }
             }
         }
@@ -42,6 +45,25 @@ public class FaultyGraphSegmentationTest {
                 Assert.assertTrue(isSubNet(candidate, sr));
             }
         }
+    }
+
+    private void onlyTerminalVerticesAreLinkedToBridges(Graph noc, SR sr) {
+        for (Vertex candidate : noc.getVertices()) {
+            if (sr.terminalVertices().contains(candidate)) {
+                Assert.assertTrue(isLinkedToBridge(candidate, noc));
+            } else {
+                Assert.assertFalse(isLinkedToBridge(candidate, noc));
+            }
+        }
+    }
+
+    private boolean isLinkedToBridge(Vertex candidate, Graph noc) {
+        for (Edge e : noc.adjunctsOf(candidate)) {
+            if (isBridge(noc, e)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private boolean isSubNet(Vertex candidate, SR sr) {


### PR DESCRIPTION
Encapsulates edge pair handling, removes some dead code, breaks find conditions (to different segment types), simplifies tVisited representation, reorders the methods, extracts 'find' break condition, extracts special case 'suitableLinks' method, makes 'find' return the segment formed or null, simplifies and renames 'find' to 'extendedSegment', adds new ctors to Segment and cleans up and reformat the code.

Not all terminal vertices are being marked as such. Broken tests are inserted showing that (commented out).